### PR TITLE
Improve demo usability

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Animated backgrounds and live number updates make the interface highly dynamic.
   starfield overlay, loading spinner and animated numbers
 - `AGENTS.md` – commit guidelines for future contributors
 
+## Quick Start
+
+For a self-contained preview, simply open `demo.html` in your browser.
+The demo bundles React and Tailwind so no build step is required. It shows
+sample data in each tab including the **Database** and **Logs** views. Use the
+Export button in the Database tab to download tables as CSV files, and watch the
+Logs tab refresh automatically every few seconds.
+
 ## Connecting to the Backend
 
 All data is fetched from a separate API. Set the environment variables
@@ -149,7 +157,8 @@ of authentication and automatic TLS.
 
 The `demo.html` file contains everything needed to preview the dashboard layout
 without running any backend. All JavaScript dependencies are embedded directly
-in the HTML so it works completely offline. To view it:
+in the HTML so it works completely offline. The demo includes database and log
+views with sample data that refresh automatically. To view it:
 
 1. Locate `demo.html` in the repository root.
 2. Open the file directly in any modern web browser (double click or use

--- a/demo.html
+++ b/demo.html
@@ -809,6 +809,45 @@
           ),
         );
       }
+      function LogsViewer() {
+        const [logs, setLogs] = useState(
+          [
+            "2024-01-01 12:00:00 INFO System started",
+            "2024-01-01 12:01:00 INFO Waiting for events",
+          ].join("\n"),
+        );
+        const refresh = () => {
+          const ts = new Date().toISOString();
+          setLogs((l) => `${l}\n${ts} INFO No new logs`);
+        };
+        useEffect(() => {
+          const id = setInterval(refresh, 5000);
+          return () => clearInterval(id);
+        }, []);
+        return /*#__PURE__*/ React.createElement(
+          "div",
+          {
+            className: "space-y-4",
+          },
+          /*#__PURE__*/ React.createElement(
+            Button,
+            {
+              variant: "outline",
+              size: "sm",
+              onClick: refresh,
+            },
+            "Refresh",
+          ),
+          /*#__PURE__*/ React.createElement(
+            "pre",
+            {
+              className:
+                "overflow-auto max-h-96 bg-black text-green-200 p-2 text-xs rounded-md",
+            },
+            logs,
+          ),
+        );
+      }
       function PortfolioAllocationDashboard() {
         const [activeTab, setActiveTab] = useState("allocation");
         const [themeDark, setThemeDark] = useState(false);
@@ -1004,7 +1043,7 @@
                   TabsTrigger,
                   {
                     value: "allocation",
-                    className: "w-1/4",
+                    className: "flex-1",
                   },
                   "Allocation",
                 ),
@@ -1012,7 +1051,7 @@
                   TabsTrigger,
                   {
                     value: "account",
-                    className: "w-1/4",
+                    className: "flex-1",
                   },
                   "Account",
                 ),
@@ -1020,7 +1059,7 @@
                   TabsTrigger,
                   {
                     value: "returns",
-                    className: "w-1/4",
+                    className: "flex-1",
                   },
                   "Returns",
                 ),
@@ -1028,9 +1067,17 @@
                   TabsTrigger,
                   {
                     value: "database",
-                    className: "w-1/4",
+                    className: "flex-1",
                   },
                   "Database",
+                ),
+                /*#__PURE__*/ React.createElement(
+                  TabsTrigger,
+                  {
+                    value: "logs",
+                    className: "flex-1",
+                  },
+                  "Logs",
                 ),
               ),
               /*#__PURE__*/ React.createElement(
@@ -1379,6 +1426,13 @@
                   value: "database",
                 },
                 /*#__PURE__*/ React.createElement(DatabaseViewer, null),
+              ),
+              /*#__PURE__*/ React.createElement(
+                TabsContent,
+                {
+                  value: "logs",
+                },
+                /*#__PURE__*/ React.createElement(LogsViewer, null),
               ),
             ),
           ),

--- a/src/PortfolioAllocationDashboard.tsx
+++ b/src/PortfolioAllocationDashboard.tsx
@@ -184,19 +184,19 @@ export default function PortfolioAllocationDashboard() {
       <Card className="mx-6 rounded-2xl shadow-xl p-4 bg-white/60 dark:bg-gray-800/60 backdrop-blur-md">
         <Tabs value={activeTab} onValueChange={setActiveTab} className="mb-6">
           <TabsList className="bg-white dark:bg-gray-800 rounded-full p-1">
-            <TabsTrigger value="allocation" className="w-1/5">
+            <TabsTrigger value="allocation" className="flex-1">
               Allocation
             </TabsTrigger>
-            <TabsTrigger value="account" className="w-1/5">
+            <TabsTrigger value="account" className="flex-1">
               Account
             </TabsTrigger>
-            <TabsTrigger value="returns" className="w-1/5">
+            <TabsTrigger value="returns" className="flex-1">
               Returns
             </TabsTrigger>
-            <TabsTrigger value="database" className="w-1/5">
+            <TabsTrigger value="database" className="flex-1">
               Database
             </TabsTrigger>
-            <TabsTrigger value="logs" className="w-1/5">
+            <TabsTrigger value="logs" className="flex-1">
               Logs
             </TabsTrigger>
           </TabsList>

--- a/src/components/LogsViewer.tsx
+++ b/src/components/LogsViewer.tsx
@@ -24,6 +24,8 @@ export default function LogsViewer({ apiBase }: Props) {
 
   useEffect(() => {
     fetchLogs();
+    const id = setInterval(fetchLogs, 5000);
+    return () => clearInterval(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiBase]);
 


### PR DESCRIPTION
## Summary
- auto-refresh logs viewer every 5s
- flexible tab layout with `flex-1`
- document CSV export and auto-refresh in demo

## Testing
- `npx prettier --write README.md src/components/LogsViewer.tsx src/PortfolioAllocationDashboard.tsx demo.html`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879596e9fe48323993bd4dbabf71ea4